### PR TITLE
refactor(Events): Clean up day marker and datetime parsing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,7 +47,7 @@ module.exports = {
       resolve: 'gatsby-source-meetup',
       options: {
         groupUrlName: 'newhavenio',
-        fields: 'featured_photo,plain_text_description,short_link',
+        fields: 'featured_photo,plain_text_description,short_link,duration',
         status: 'upcoming',
         desc: 'false',
         page: 10,

--- a/src/components/shared/day/day.css.js
+++ b/src/components/shared/day/day.css.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { space } from 'styled-system';
 
 export const Container = styled.div`

--- a/src/components/shared/day/day.js
+++ b/src/components/shared/day/day.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  parseISO,
   format,
   differenceInCalendarDays,
   startOfToday,
@@ -10,46 +9,54 @@ import {
 
 import * as Styled from './day.css';
 
+/**
+ * Algorithm:
+ * 1. If the event is today...
+ *    1. ...and the start time is past, show 'Now!'
+ *    2. ...and the start time is future, show 'Today'
+ * 2. If the event is tomorrow, show 'Tomorrow'
+ * 3. If the event is this week, show 'In N days'
+ * 4. If the event is in 2 weeks, show 'In 2 weeks'
+ * 5. Show nothing
+ */
 const renderDaysAway = date => {
   const daysAway = differenceInCalendarDays(date, startOfToday());
 
   if (daysAway === 0) {
     return isPast(date) ? (
-      <Styled.DaysAway featured>Happening now!</Styled.DaysAway>
+      <Styled.DaysAway featured>Now!</Styled.DaysAway>
     ) : (
       <Styled.DaysAway featured>Today</Styled.DaysAway>
     );
   } else if (daysAway === 1) {
-    return <Styled.DaysAway>Tomorrow</Styled.DaysAway>;
+    return <Styled.DaysAway featured>Tomorrow</Styled.DaysAway>;
   } else if (daysAway < 7) {
     return <Styled.DaysAway>In {daysAway} days</Styled.DaysAway>;
+  } else if (daysAway < 14) {
+    return <Styled.DaysAway>In 2 weeks</Styled.DaysAway>;
   }
 };
 
 /**
  * A static display component that provides padding and a slight shadow.
  */
-const Day = ({ date }) => {
-  const parsedDate = parseISO(date);
-  const dayOfWeek = format(parsedDate, 'EEEE');
-  const dateNumber = format(parsedDate, 'd');
-  const month = format(parsedDate, 'MMM');
+const Day = ({ datetime }) => {
+  const dayOfWeek = format(datetime, 'EEEE');
+  const dateNumber = format(datetime, 'd');
+  const month = format(datetime, 'MMM');
 
   return (
     <Styled.Container>
       <Styled.DayOfWeek>{dayOfWeek}</Styled.DayOfWeek>
       <Styled.DateNumber>{dateNumber}</Styled.DateNumber>
       <Styled.Month>{month}</Styled.Month>
-      {renderDaysAway(parsedDate)}
+      {renderDaysAway(datetime)}
     </Styled.Container>
   );
 };
 
 Day.propTypes = {
-  /**
-   * ISO-8601 date string
-   */
-  date: PropTypes.string.isRequired,
+  datetime: PropTypes.instanceOf(Date),
 };
 
 export default Day;

--- a/src/components/shared/eventcard/eventcard.js
+++ b/src/components/shared/eventcard/eventcard.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import P from 'prop-types';
-import { parse, format } from 'date-fns';
+import { format } from 'date-fns';
 
 import Day from 'components/shared/day';
 import Box from 'components/shared/box';
@@ -27,8 +27,7 @@ import {
 const EventCard = ({ event, type }) => {
   const {
     featured_photo,
-    local_date,
-    local_time,
+    datetime,
     name,
     plain_text_description,
     short_link,
@@ -39,8 +38,7 @@ const EventCard = ({ event, type }) => {
   const isCompact = type === 'compact';
 
   const [short_description] = plain_text_description.split('\n');
-  const parsedDateTime = parse(local_time, 'HH:mm', new Date());
-  const formattedTime = format(parsedDateTime, 'h:mm a');
+  const formattedTime = format(datetime, 'h:mm a');
 
   const onCardClick = useCallback(() => window.open(short_link), [short_link]);
 
@@ -52,7 +50,7 @@ const EventCard = ({ event, type }) => {
         px={isCompact ? 0 : { _: 24, sm: 32 }}
         gridArea="date"
       >
-        <Day date={local_date} alignItems={{ _: 'start', sm: 'center' }} />
+        <Day datetime={datetime} alignItems={{ _: 'start', sm: 'center' }} />
       </Box>
       <Box
         p={isCompact ? 0 : 32}

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -1,0 +1,3 @@
+// We use milliseconds because it's what Meetup uses for some stupid reason
+const HOUR = 1000 * 60 * 60;
+export const GUESSTIMATED_EVENT_LENGTH_MS = 2 * HOUR;


### PR DESCRIPTION
- Cleans up datetime parsing logic. Now we parse the entire date + time
  up front as a single ISO-8601 string and store it on the event object
  itself so all consumers can easily access it. This makes `eventcard`
  and `day` simpler by removing parsing boilerplate.
- Add `duration` to the query field so we can filter out events that
  have passed. This is needed because stale events might exist on the
  site due to the site only being rebuilt once a day.
- Change events filter such that instead of screening out events that
  are before today, it secreens out events whose start times are >2
  hours before the current time. We use 2 hours as an estimate of the
  average event length.
  - This fixes the case where events that happened earlier today are
    shown as 'happening now'.